### PR TITLE
Added stopPropagation and preventDefault to onChange

### DIFF
--- a/src/EnhancedSwitch.js
+++ b/src/EnhancedSwitch.js
@@ -265,6 +265,8 @@ class EnhancedSwitch extends React.Component {
     }
 
     if (this.props.onChange && !this.props.label) {
+      event.preventDefault();
+      event.stopPropagation();
       this.props.onChange(event, newChecked);
     }
   }


### PR DESCRIPTION
This fixes a bug when you wrap react-icheck in a label, as it currently
will trigger the onChange event twice (once when you click the checkbox,
once when the event bubbles up to the label).

This is inline with ichecks implementation see
https://github.com/fronteed/icheck/blob/1.x/icheck.js#L218

Note, that I'd prefer to not stop the event bubble chain, but due to ichecks implementation, I'm not sure there's any other way to fix this bug.
