### PR TITLE
Moved stopPropagation and prevent default to always trigger on ins onChange

### DIFF
--- a/src/EnhancedSwitch.js
+++ b/src/EnhancedSwitch.js
@@ -264,9 +264,9 @@ class EnhancedSwitch extends React.Component {
       });
     }
 
+    event.preventDefault();
+    event.stopPropagation();
     if (this.props.onChange && !this.props.label) {
-      event.preventDefault();
-      event.stopPropagation();
       this.props.onChange(event, newChecked);
     }
   }


### PR DESCRIPTION
onChange

Update to my previous fix to add preventDefault and stopPropagation in
order to always trigger even if there is no onChange handler or no
label set. Otherwise the double-trigger bug still exists when there is a label but no
onChange handler.
