### PR TITLE
Fixed "position: relative" issue

### DIFF
--- a/examples/src/js/components/examples/style.scss
+++ b/examples/src/js/components/examples/style.scss
@@ -1,38 +1,28 @@
 .icheckbox_minimal, .icheckbox_minimal-red, .icheckbox_minimal-green, .icheckbox_minimal-blue, .icheckbox_minimal-aero, .icheckbox_minimal-grey, .icheckbox_minimal-orange, .icheckbox_minimal-yellow, .icheckbox_minimal-pink, .icheckbox_minimal-purple, .iradio_minimal, .iradio_minimal-red, .iradio_minimal-green, .iradio_minimal-blue, .iradio_minimal-aero, .iradio_minimal-grey, .iradio_minimal-orange, .iradio_minimal-yellow, .iradio_minimal-pink, .iradio_minimal-purple {
-  position: relative;
-
   + span {
     padding-left: 18px;
   }
 }
 
 .icheckbox_square, .icheckbox_square-red, .icheckbox_square-green, .icheckbox_square-blue, .icheckbox_square-aero, .icheckbox_square-grey, .icheckbox_square-orange, .icheckbox_square-yellow, .icheckbox_square-pink, .icheckbox_square-purple, .iradio_square, .iradio_square-red, .iradio_square-green, .iradio_square-blue, .iradio_square-aero, .iradio_square-grey, .iradio_square-orange, .iradio_square-yellow, .iradio_square-pink, .iradio_square-purple {
-  position: relative;
-
   + span {
     padding-left: 18px;
   }
 }
 
 .icheckbox_flat, .icheckbox_flat-red, .icheckbox_flat-green, .icheckbox_flat-blue, .icheckbox_flat-aero, .icheckbox_flat-grey, .icheckbox_flat-orange, .icheckbox_flat-yellow, .icheckbox_flat-pink, .icheckbox_flat-purple, .iradio_flat, .iradio_flat-red, .iradio_flat-green, .iradio_flat-blue, .iradio_flat-aero, .iradio_flat-grey, .iradio_flat-orange, .iradio_flat-yellow, .iradio_flat-pink, .iradio_flat-purple {
-  position: relative;
-
   + span {
     padding-left: 18px;
   }
 }
 
 .icheckbox_polaris, .iradio_polaris {
-  position: relative;
-
   + span {
     padding-left: 18px;
   }
 }
 
 .icheckbox_futurico, .iradio_futurico {
-  position: relative;
-
   + span {
     padding-left: 18px;
   }

--- a/src/EnhancedSwitch.js
+++ b/src/EnhancedSwitch.js
@@ -207,7 +207,9 @@ class EnhancedSwitch extends React.Component {
 
   adjustStyle() {
     const { inputContainer } = this.refs;
-    if (inputContainer.style.position === 'static') {
+    const { position } = window.getComputedStyle(inputContainer);
+
+    if (position === 'static') {
       inputContainer.style.position = 'relative';
     }
   }


### PR DESCRIPTION
Hello and first of all thanks for the great port of iCheck to react!
I've run into some issues where position: relative needed to manually be added to each css theme style like done on the example site.

After some digging it turns out this is because of an incorrect port of https://github.com/fronteed/icheck/blob/cf738c22bd543f99cdf76febb207371b1be8f611/icheck.js#L186 which uses jquery's `css()` function that under the hood calls `getComputedStyle`, `style.position` will only have a value in case it's set directly which as far as I can tell will never happen.

I've removed the unneeded position: relative from the demo site and fixed the issue in this 
