### PR TITLE
Label class name additional fixes

### DIFF
--- a/src/EnhancedSwitch.js
+++ b/src/EnhancedSwitch.js
@@ -321,6 +321,7 @@ class EnhancedSwitch extends React.Component {
       activeClass,
       labelHover,
       labelHoverClass,
+	  labelClassName,
       inheritClass,
       inheritID,
       aria,
@@ -499,8 +500,8 @@ class EnhancedSwitch extends React.Component {
     };
 
     // add className prop for outer label
-    if (this.props.labelClassName) {
-      labelProps.className = this.props.labelClassName;
+    if (labelClassName) {
+      labelProps.className = labelClassName;
     }
 
     return (

--- a/src/EnhancedSwitch.js
+++ b/src/EnhancedSwitch.js
@@ -321,7 +321,7 @@ class EnhancedSwitch extends React.Component {
       activeClass,
       labelHover,
       labelHoverClass,
-	  labelClassName,
+      labelClassName,
       inheritClass,
       inheritID,
       aria,


### PR DESCRIPTION
The labelClassName prop was being added to the 'other' props and therefore being passed to the input which caused a 'Unknown prop `labelClassName` on <input> tag.'.
