### PR TITLE
Fix prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "babel-runtime": "^5.8.38",
     "classnames": "^2.2.3",
-    "icheck": "^1.0.2"
+    "icheck": "^1.0.2",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel": "^5.8.38",

--- a/src/EnhancedSwitch.js
+++ b/src/EnhancedSwitch.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const _iCheck = 'iCheck';
@@ -7,106 +8,106 @@ const _iCheckHelper = _iCheck + '-helper';
 class EnhancedSwitch extends React.Component {
 
   static propTypes = {
-    inputType: React.PropTypes.string.isRequired,
+    inputType: PropTypes.string.isRequired,
 
-    checked: React.PropTypes.bool,
-    defaultChecked: React.PropTypes.bool,
+    checked: PropTypes.bool,
+    defaultChecked: PropTypes.bool,
 
-    label: React.PropTypes.node,
+    label: PropTypes.node,
 
-    disabled: React.PropTypes.bool,
+    disabled: PropTypes.bool,
 
-    indeterminate: React.PropTypes.bool,
+    indeterminate: PropTypes.bool,
 
-    onChange: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
-    onFocus: React.PropTypes.func,
+    onChange: PropTypes.func,
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
 
     // base class added to customized checkboxes
-    checkboxClass: React.PropTypes.string,
+    checkboxClass: PropTypes.string,
 
     // base class added to customized radio buttons
-    radioClass: React.PropTypes.string,
+    radioClass: PropTypes.string,
 
     // class added on checked state (input.checked = true)
-    checkedClass: React.PropTypes.string,
+    checkedClass: PropTypes.string,
 
     // if not empty, used instead of 'checkedClass' option (input type specific)
-    checkedCheckboxClass: React.PropTypes.string,
-    checkedRadioClass: React.PropTypes.string,
+    checkedCheckboxClass: PropTypes.string,
+    checkedRadioClass: PropTypes.string,
 
     // if not empty, added as class name on unchecked state (input.checked = false)
-    uncheckedClass: React.PropTypes.string,
+    uncheckedClass: PropTypes.string,
 
     // if not empty, used instead of 'uncheckedClass' option (input type specific)
-    uncheckedCheckboxClass: React.PropTypes.string,
-    uncheckedRadioClass: React.PropTypes.string,
+    uncheckedCheckboxClass: PropTypes.string,
+    uncheckedRadioClass: PropTypes.string,
 
     // class added on disabled state (input.disabled = true)
-    disabledClass: React.PropTypes.string,
+    disabledClass: PropTypes.string,
 
     // if not empty, used instead of 'disabledClass' option (input type specific)
-    disabledCheckboxClass: React.PropTypes.string,
-    disabledRadioClass: React.PropTypes.string,
+    disabledCheckboxClass: PropTypes.string,
+    disabledRadioClass: PropTypes.string,
 
     // if not empty, added as class name on enabled state (input.disabled = false)
-    enabledClass: React.PropTypes.string,
+    enabledClass: PropTypes.string,
 
     // if not empty, used instead of 'enabledClass' option (input type specific)
-    enabledCheckboxClass: React.PropTypes.string,
-    enabledRadioClass: React.PropTypes.string,
+    enabledCheckboxClass: PropTypes.string,
+    enabledRadioClass: PropTypes.string,
 
     // class added on indeterminate state (input.indeterminate = true)
-    indeterminateClass: React.PropTypes.string,
+    indeterminateClass: PropTypes.string,
 
     // if not empty, used instead of 'indeterminateClass' option (input type specific)
-    indeterminateCheckboxClass: React.PropTypes.string,
-    indeterminateRadioClass: React.PropTypes.string,
+    indeterminateCheckboxClass: PropTypes.string,
+    indeterminateRadioClass: PropTypes.string,
 
     // if not empty, added as class name on determinate state (input.indeterminate = false)
-    determinateClass: React.PropTypes.string,
+    determinateClass: PropTypes.string,
 
     // if not empty, used instead of 'determinateClass' option (input type specific)
-    determinateCheckboxClass: React.PropTypes.string,
-    determinateRadioClass: React.PropTypes.string,
+    determinateCheckboxClass: PropTypes.string,
+    determinateRadioClass: PropTypes.string,
 
     // class added on hover state (pointer is moved onto input)
-    hoverClass: React.PropTypes.string,
+    hoverClass: PropTypes.string,
 
     // class added on focus state (input has gained focus)
-    focusClass: React.PropTypes.string,
+    focusClass: PropTypes.string,
 
     // class added on active state (mouse button is pressed on input)
-    activeClass: React.PropTypes.string,
+    activeClass: PropTypes.string,
 
     // adds hoverClass to customized input on label hover and labelHoverClass to label on input hover
-    labelHover: React.PropTypes.bool,
+    labelHover: PropTypes.bool,
 
     // class added to label if labelHover set to true
-    labelHoverClass: React.PropTypes.string,
+    labelHoverClass: PropTypes.string,
 
     // increase clickable area by given % (negative number to decrease)
-    increaseArea: React.PropTypes.string,
+    increaseArea: PropTypes.string,
 
     // true to set 'pointer' CSS cursor over enabled inputs and 'default' over disabled
-    cursor: React.PropTypes.bool,
+    cursor: PropTypes.bool,
 
     // set true to inherit original input's class name
-    inheritClass: React.PropTypes.bool,
+    inheritClass: PropTypes.bool,
 
     // if set to true, input's id is prefixed with 'iCheck-' and attached
-    inheritID: React.PropTypes.bool,
+    inheritID: PropTypes.bool,
 
     // set true to activate ARIA support
-    aria: React.PropTypes.bool,
+    aria: PropTypes.bool,
 
     // add HTML code or text inside customized input
-    insert: React.PropTypes.node,
+    insert: PropTypes.node,
 
-    children: React.PropTypes.node,
+    children: PropTypes.node,
 
     // class added for outer label
-    labelClassName: React.PropTypes.string,
+    labelClassName: PropTypes.string,
   };
 
   static defaultProps = {

--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import RadioButton from './Radio';
 
 class RadioGroup extends React.Component {
@@ -7,7 +8,7 @@ class RadioGroup extends React.Component {
     /**
      * The name that will be applied to all radio buttons inside it.
      */
-    name: React.PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
 
     /**
      * Sets the default radio button to be the one whose
@@ -15,29 +16,29 @@ class RadioGroup extends React.Component {
      * This will override any individual radio button with
      * the defaultChecked or checked property stated.
      */
-    defaultValue: React.PropTypes.string,
+    defaultValue: PropTypes.string,
 
     /**
      * The value of the currently selected radio button.
      */
-    value: React.PropTypes.string,
+    value: PropTypes.string,
 
     /**
      * Callback function that is fired when a radio button has
      * been clicked. Returns the event and the value of the radio
      * button that has been selected.
      */
-    onChange: React.PropTypes.func,
+    onChange: PropTypes.func,
 
     /**
      * Should be used to pass `Radio` components.
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
 
     /**
      * The css class name of the root element.
      */
-    className: React.PropTypes.string,
+    className: PropTypes.string,
   };
 
   constructor(props) {


### PR DESCRIPTION
Hi there! In the latest react release there is a deprecation warning about using `React.PropTypes`.  You can read more on the [react blog](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html).

![image](https://cloud.githubusercontent.com/assets/6333409/25025863/a71aed18-20ac-11e7-8e5b-37d5f6ba7b53.png)

This PR, adds `prop-types` as a dependency and replaces the use of `React.PropTypes` to use them from the separate library.

A similar replacement example can be found at https://github.com/reactjs/react-modal/pull/374.

Ps. It would be great if you can cut a new release for this one since it will make the console warning-free again 😄 