### PR TITLE
Update React peer dependency to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "react": "^15"
+    "react": "^16"
   },
   "dependencies": {
     "babel-runtime": "^5.8.38",


### PR DESCRIPTION
Please update to remove npm warnings about not having an old version of react available